### PR TITLE
Bugfix for issue #31

### DIFF
--- a/src/single_experiment_pass_k.py
+++ b/src/single_experiment_pass_k.py
@@ -26,7 +26,9 @@ def for_file(path):
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("dirs", type=str,  help="directories with results", nargs="+")
+    parser.add_argument("dirs", type=str,  help="Directories with results. \
+                        Make sure they are labeled with completion temperature. \
+                        If they have '0.2' in their name, pass@1 will be ran rather than pass@10 and pass@100.", nargs="+")
     args = parser.parse_args()
     print("Dataset,Pass@k,Estimate")
     for d in args.dirs:
@@ -34,7 +36,7 @@ def main():
         if len(result_array) == 0:
             continue
         result = result_array.mean(axis=0)
-        name = d.split("/")[-1]
+        name = d.split("/")[-1] if d.split("/")[-1] != "" else d.split("/")[-2]
         if "0.2" in name:
             print(f"{name},1,{result[0]:.2f}")
         else:


### PR DESCRIPTION
Issue #31 noted that when a "/" was put in the directories string, it wouldn't properly run the pass@k for that output. They also noted the lack of documentation of when pass@1 was ran.  I fixed both of these issues by fixing how the name variable was made and by adding extra description to the help message. However, I did not change  how the estimator works.