### PR TITLE
Escapes $ and " in julia translator

### DIFF
--- a/dataset_builder/humaneval_to_jl.py
+++ b/dataset_builder/humaneval_to_jl.py
@@ -144,9 +144,11 @@ class Translator:
         if type(c) == bool:
             return str(c).lower()
         if type(c) == str:
-            if '"' in c:
-                raise Exception("smarter quote handling")
-            return '"' + c + '"'
+            escaped = c.translate(str.maketrans({
+                '"': r"\"",
+                "$": r"\$"
+            }))
+            return '"' + escaped + '"'
         if c is None: 
             return "nothing"
         return repr(c)


### PR DESCRIPTION
Following the bugs found in the google paper, this PR fixes my grave error of forgetting to escape $ in prompt strings. 