### PR TITLE
Local datasets are JSON arrays, not JSON-L

### DIFF
--- a/multipl_e/completions.py
+++ b/multipl_e/completions.py
@@ -37,7 +37,7 @@ def from_remote_dataset(args):
 
 def from_local_dataset(args):
     with open(args.dataset, "r") as f:
-        problems_list = [ json.loads(line) for line in f ]
+        problems_list = json.load(f) 
         start_index = (
             args.input_start_index if args.input_start_index is not None else 0
         )


### PR DESCRIPTION
In `multipl_e/completions.py:from_local_dataset`, the JSON file was read as if it were a JSON-L file (i.e. each object on a separate line); however, `dataset_builder/prepare_prompts_json.py`, and thus `dataset_builder/all_prepare_prompts.py`, produce JSON arrays, where each line is just a single field in an object. This change fixes the interface mismatch. 