### PR TITLE
Add vLLM support

### DIFF
--- a/automodel_vllm.py
+++ b/automodel_vllm.py
@@ -10,9 +10,9 @@ import torch
 class VLLM:
     def __init__(self, name, revision, tokenizer_name=None):
         assert revision is None, "TODO: implement revision"
-        dtype = torch.float16
+        dtype = "float16"
         if torch.cuda.is_bf16_supported():
-            dtype = torch.bfloat16
+            dtype = "bfloat16"
         self.model = LLM(
             model=name,
             tokenizer=tokenizer_name,

--- a/automodel_vllm.py
+++ b/automodel_vllm.py
@@ -4,14 +4,19 @@ This script produces completions for roughly any AutoModelForCausalLM.
 from typing import List
 from multipl_e.completions import make_main, stop_at_stop_token, partial_arg_parser
 from vllm import LLM, SamplingParams
+import torch
 
 
 class VLLM:
     def __init__(self, name, revision, tokenizer_name=None):
         assert revision is None, "TODO: implement revision"
+        dtype = torch.float16
+        if torch.cuda.is_bf16_supported():
+            dtype = torch.bfloat16
         self.model = LLM(
             model=name,
             tokenizer=tokenizer_name,
+            dtype=dtype,
             # TODO: this doesn't work as of now, implement later
             #  revision=revision,
             trust_remote_code=True,

--- a/automodel_vllm.py
+++ b/automodel_vllm.py
@@ -8,8 +8,14 @@ from vllm import LLM, SamplingParams
 
 class VLLM:
     def __init__(self, name, revision, tokenizer_name=None):
-        self.model = LLM(model=name, tokenizer=tokenizer_name,
-                         revision=revision, trust_remote_code=True)
+        assert revision is None, "TODO: implement revision"
+        self.model = LLM(
+            model=name,
+            tokenizer=tokenizer_name,
+            # TODO: this doesn't work as of now, implement later
+            #  revision=revision,
+            trust_remote_code=True,
+        )
 
     def completions(
         self, prompts: List[str], max_tokens: int, temperature: float, top_p, stop

--- a/automodel_vllm.py
+++ b/automodel_vllm.py
@@ -1,0 +1,57 @@
+"""
+This script produces completions for roughly any AutoModelForCausalLM.
+"""
+from typing import List
+from multipl_e.completions import make_main, stop_at_stop_token, partial_arg_parser
+from vllm import LLM, SamplingParams
+
+
+class VLLM:
+    def __init__(self, name, revision, tokenizer_name=None):
+        self.model = LLM(model=name, tokenizer=tokenizer_name,
+                         revision=revision, trust_remote_code=True)
+
+    def completions(
+        self, prompts: List[str], max_tokens: int, temperature: float, top_p, stop
+    ):
+        prompts = [prompt.strip() for prompt in prompts]
+        params = SamplingParams(temperature=temperature,
+                                top_p=top_p, max_tokens=max_tokens, stop=stop)
+        outputs = self.model.generate(prompts, params)
+        return [stop_at_stop_token(o.outputs[0].text, stop) for o in outputs]
+
+
+def automodel_partial_arg_parser():
+    """
+    This is also used by peftmodel.py.
+    """
+    args = partial_arg_parser()
+    args.add_argument("--name", type=str, required=True)
+    args.add_argument("--revision", type=str)
+    args.add_argument("--tokenizer_name", type=str)
+    args.add_argument("--name-override", type=str)
+    return args
+
+
+def do_name_override(args):
+    """
+    Applies the --name-override flag, or uses the model name, correcting / and - which the rest of
+    the toolchain does not like.
+    """
+    if args.name_override:
+        name = args.name_override
+    else:
+        name = args.name.replace("/", "_").replace("-", "_")
+    return name
+
+
+def main():
+    args = automodel_partial_arg_parser()
+    args = args.parse_args()
+    model = VLLM(args.name, args.revision, args.tokenizer_name)
+    name = do_name_override(args)
+    make_main(args, name, model.completions)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
My tests conclude that the vLLM automodel script is 3x faster (with StarCoder on a H100 80GB gpu) than the transformers automodel script. This is great!

```
Dataset: HumanEval Py
Batch size: 20
Completion limit: 20
Temperature: 0.2
Model: bigcode/starcoder

# vLLM HumanEval-py run
real  15m8.228s
user  14m57.769s
sys 2m29.523s

# transformers HumanEval-py run
real  45m58.771s
user  44m50.852s
sys 1m25.077s
```

Here are the evaluations of both runs:
```
Dataset,Pass@k,Estimate,NumProblems,MinCompletions,MaxCompletions
vllm,1,0.3394409937888199,161,20,20
transformers,1,0.3437888198757764,161,20,20
```
