### PR TITLE
A few small fixes for the untranslated datasets

### DIFF
--- a/datasets/mbpp-typed/mbpp_222_check_type.py
+++ b/datasets/mbpp-typed/mbpp_222_check_type.py
@@ -1,6 +1,6 @@
-from typing import List, Dict, Tuple
+from typing import Any, Tuple
 
-def check_type(test_tuple: Any) -> bool:
+def check_type(test_tuple: Tuple[Any, ...]) -> bool:
     """
 	Write a function to check if all the elements in tuple have same data type or not.
 	"""

--- a/datasets/mbpp-typed/mbpp_262_split_two_parts.py
+++ b/datasets/mbpp-typed/mbpp_262_split_two_parts.py
@@ -1,6 +1,6 @@
-from typing import List, Dict, Tuple
+from typing import Any, List, Tuple
 
-def split_two_parts(list1: List[Any], L: int) -> Any:
+def split_two_parts(list1: List[Any], L: int) -> Tuple[List[Any], List[Any]]:
     """
 	Write a function that takes in a list and an integer L and splits the given list into two parts where the length of the first part of the list is L, and returns the resulting lists in a tuple.
 	"""

--- a/datasets/mbpp-typed/mbpp_407_rearrange_bigger.py
+++ b/datasets/mbpp-typed/mbpp_407_rearrange_bigger.py
@@ -1,6 +1,6 @@
-from typing import List, Dict, Tuple
+from typing import Union
 
-def rearrange_bigger(n: int) -> Any:
+def rearrange_bigger(n: int) -> Union[int, bool]:
     """
 	Write a function to create the next bigger number by rearranging the digits of a given number.
 	"""

--- a/datasets/mbpp-typed/mbpp_413_extract_nth_element.py
+++ b/datasets/mbpp-typed/mbpp_413_extract_nth_element.py
@@ -1,6 +1,6 @@
-from typing import List, Dict, Tuple
+from typing import List, Tuple, Union
 
-def extract_nth_element(list1: List[Tuple[str, int, int]], n: int) -> List[Any]:
+def extract_nth_element(list1: List[Tuple[str, int, int]], n: int) -> List[Union[str, int]]:
     """
 	Write a function to extract the nth element from a given list of tuples.
 	"""

--- a/datasets/mbpp-typed/mbpp_446_count_Occurrence.py
+++ b/datasets/mbpp-typed/mbpp_446_count_Occurrence.py
@@ -1,6 +1,6 @@
-from typing import List, Dict, Tuple
+from typing import Any, List, Tuple
 
-def count_Occurrence(tup: Any, lst: List[Any]) -> int:
+def count_Occurrence(tup: Tuple[Any, ...], lst: List[Any]) -> int:
     """
 	Write a python function to count the occurence of all elements of list in a tuple.
 	"""

--- a/datasets/mbpp-typed/mbpp_587_list_tuple.py
+++ b/datasets/mbpp-typed/mbpp_587_list_tuple.py
@@ -1,6 +1,6 @@
-from typing import List, Dict, Tuple
+from typing import List, Tuple
 
-def list_tuple(listx: List[int]) -> Any:
+def list_tuple(listx: List[int]) -> Tuple[int, ...]:
     """
 	Write a function to convert a list to a tuple.
 	"""

--- a/datasets/mbpp-typed/mbpp_595_min_Swaps.py
+++ b/datasets/mbpp-typed/mbpp_595_min_Swaps.py
@@ -1,6 +1,6 @@
-from typing import List, Dict, Tuple
+from typing import Literal, Union
 
-def min_Swaps(str1: str, str2: str) -> Any:
+def min_Swaps(str1: str, str2: str) -> Union[int, Literal['Not Possible']]:
     """
 	Write a python function to count minimum number of swaps required to convert one binary number represented as a string to another.
 	"""

--- a/datasets/mbpp-typed/mbpp_725_extract_quotation.py
+++ b/datasets/mbpp-typed/mbpp_725_extract_quotation.py
@@ -1,6 +1,6 @@
-from typing import List, Dict, Tuple
+from typing import List
 
-def extract_quotation(text1: str) -> List[Any]:
+def extract_quotation(text1: str) -> List[str]:
     """
 	Write a function to extract values between quotation marks " " of the given string.
 	"""

--- a/datasets/mbpp-typed/mbpp_726_multiply_elements.py
+++ b/datasets/mbpp-typed/mbpp_726_multiply_elements.py
@@ -1,6 +1,6 @@
-from typing import List, Dict, Tuple
+from typing import List
 
-def multiply_elements(test_tup: List[int]) -> List[Any]:
+def multiply_elements(test_tup: List[int]) -> List[int]:
     """
 	Write a function that takes as input a list of numbers (t_1,...,t_{N+1}) and returns a list of length N where the i-th element of the tuple is equal to t_i * t_{i+1}.
 	"""

--- a/datasets/mbpp-typed/mbpp_744_check_none.py
+++ b/datasets/mbpp-typed/mbpp_744_check_none.py
@@ -1,6 +1,6 @@
-from typing import List, Dict, Tuple
+from typing import Any, Tuple
 
-def check_none(test_tup: Any) -> bool:
+def check_none(test_tup: Tuple[Any, ...]) -> bool:
     """
 	Write a function to check if the given tuple has any none value or not.
 	"""

--- a/datasets/mbpp-typed/mbpp_754_extract_index_list.py
+++ b/datasets/mbpp-typed/mbpp_754_extract_index_list.py
@@ -1,6 +1,6 @@
-from typing import List, Dict, Tuple
+from typing import List
 
-def extract_index_list(l1: List[int], l2: List[int], l3: List[int]) -> List[Any]:
+def extract_index_list(l1: List[int], l2: List[int], l3: List[int]) -> List[int]:
     """
 	We say that an element is common for lists l1, l2, l3 if it appears in all three lists under the same index. Write a function to find common elements from three lists. The function should return a list.
 	"""

--- a/datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py
+++ b/datasets/originals-with-cleaned-doctests/HumanEval_142_sum_squares.py
@@ -2,17 +2,17 @@ from typing import List
 
 def sum_squares(lst: List[int]) -> int:
     """"
-    This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a 
-    multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not 
-    change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries. 
-    
+    This function will take a list of integers. For all entries in the list, the function shall square the integer entry if its index is a
+    multiple of 3 and will cube the integer entry if its index is a multiple of 4 and not a multiple of 3. The function will not
+    change the entries in the list whose indexes are not a multiple of 3 or 4. The function shall then return the sum of all entries.
+
     Examples:
-    >>> lst 
-    [1,2,3] 
-    >>> lst 
-    []  
-    >>> lst 
-    [-1,-5,2,-1,-5]
+    >>> sum_squares([1,2,3])
+    6
+    >>> sum_squares([])
+    0
+    >>> sum_squares([-1,-5,2,-1,-5])
+    -126
     """
     ### Canonical solution below ###
     result =[]
@@ -29,7 +29,7 @@ def sum_squares(lst: List[int]) -> int:
 def check(candidate):
 
     # Check some simple cases
-    
+
     assert candidate([1,2,3]) == 6
     assert candidate([1,4,9]) == 14
     assert candidate([]) == 0
@@ -41,8 +41,8 @@ def check(candidate):
     assert candidate([-1,0,0,0,0,0,0,0,-1]) == 0
     assert candidate([-16, -9, -2, 36, 36, 26, -20, 25, -40, 20, -4, 12, -26, 35, 37]) == -14196
     assert candidate([-1, -3, 17, -1, -15, 13, -1, 14, -14, -12, -5, 14, -14, 6, 13, 11, 16, 16, 4, 10]) == -1448
-    
-    
+
+
     # Don't remove this line:
 def test_check():
     check(sum_squares)

--- a/datasets/originals-with-cleaned-doctests/HumanEval_69_search.py
+++ b/datasets/originals-with-cleaned-doctests/HumanEval_69_search.py
@@ -2,14 +2,14 @@ from typing import List
 
 def search(lst: List[int]) -> int:
     '''
-    You are given a non-empty list of positive integers. Return the greatest integer that is greater than 
-    zero, and has a frequency greater than or equal to the value of the integer itself. 
+    You are given a non-empty list of positive integers. Return the greatest integer that is greater than
+    zero, and has a frequency greater than or equal to the value of the integer itself.
     The frequency of an integer is the number of times it appears in the list.
     If no such a value exist, return -1.
     Examples:
     >>> search([4, 1, 2, 2, 3, 1])
     2
-    >>>  search([1, 2, 2, 3, 3, 3, 4, 4, 4])
+    >>> search([1, 2, 2, 3, 3, 3, 4, 4, 4])
     3
     >>> search([5, 5, 4, 4, 4])
     -1
@@ -23,7 +23,7 @@ def search(lst: List[int]) -> int:
     for i in range(1, len(frq)):
         if frq[i] >= i:
             ans = i
-    
+
     return ans
 
 ### Unit tests below ###


### PR DESCRIPTION
Hi, while working on https://github.com/nuprl/MultiPL-E/pull/162, I was digging into some translation issues and ran across a few things in the untranslated datasets that I thought should probably be updated.

I've included two commits. The first makes a few mionr changes to doctests, one of which is just a change in whitespacing, while the other fixes an issue with the doctest that causes a translation failure. The second commit includes a few typehint changes, mostly for cases where `Any` was used, but a more descriptive type could have been used instead.

While I think most of the changes are fine (totally unbiased, of course), I suspect the two most objectional changes will be:

1. Increasing the use of `Tuple[T, ...]`
    This indicates that a Tuple could have [any length, with all elements being of type T](https://docs.python.org/3/library/typing.html#annotating-tuples). These changes generally replace instances of `Any` with either `Tuple[Any, ...]` or `Tuple[some_type, ...]`

    However there are some translators, like the one for typescript, that support `Any` but do not support the ellipsis notation in Tuples, hence why maybe this change could be objectional.

2. MBPP_595
    I'm convinced it is impossible to pass this problem as it is currently written without cheating. It's typed to just return `Any`. The docstring doesn't include any guidance about the expected output format. Most logically, this would be either `int | None`, or `int` and `-1` is used to represent that it's impossible. I don't believe anyone would guess that the expected output format is `int | 'Not Possible'`. So, while I would be very surprised if any of the translators support translating this typehint (`Union[int, Literal['Not Possible']]`), without this change I'm not sure how any model is expected to generate a correct solution for this problem

<details>
<summary>For completeness here are the changes in translation ratio that I observed:</summary>

| Difference | Before | After | Lang     | prompt-terminology | doctests  | originals                       |
|------------|--------|-------|----------|--------------------|-----------|---------------------------------|
| -0.01      | 0.97   | 0.96  | ts    | reworded           | transform | mbpp-typed                      |
| -0.01      | 0.97   | 0.96  | ts    | verbatim           | keep      | mbpp-typed                      |
| -0.01      | 0.97   | 0.96  | jl    | reworded           | transform | mbpp-typed                      |
| -0.01      | 0.97   | 0.96  | jl    | verbatim           | keep      | mbpp-typed                      |
| -0.01      | 0.94   | 0.93  | go    | reworded           | transform | mbpp-typed                      |
| -0.01      | 0.94   | 0.93  | go    | verbatim           | keep      | mbpp-typed                      |
| 0.01       | 0.98   | 0.99  | swift | reworded           | transform | originals-with-cleaned-doctests |
| 0.01       | 0.98   | 0.99  | swift | verbatim           | transform | originals-with-cleaned-doctests |
| 0.01       | 0.89   | 0.9   | ml    | reworded           | transform | mbpp-typed                      |
| 0.01       | 0.89   | 0.9   | ml    | verbatim           | keep      | mbpp-typed                      |
| 0.01       | 0.89   | 0.9   | hs    | reworded           | transform | mbpp-typed                      |
| 0.01       | 0.89   | 0.9   | hs    | verbatim           | keep      | mbpp-typed                      |
| 0.01       | 0.9    | 0.91  | ada   | reworded           | transform | mbpp-typed                      |
| 0.01       | 0.97   | 0.98  | ada   | reworded           | transform | originals-with-cleaned-doctests |
| 0.01       | 0.9    | 0.91  | ada   | verbatim           | keep      | mbpp-typed                      |
| 0.01       | 0.97   | 0.98  | ada   | verbatim           | transform | originals-with-cleaned-doctests |
</details>

<details>
<summary>Full summary of changes</summary>

- HumanEval 69 (cleaned-doctests): Removed an extra whitespace that was in one of the doctests
- HumanEval 142 (cleaned-doctests): Fixed the doctests, which were causing a translation failure
- MBPP 222 (typed): Changed `Any` to `Tuple[Any, ...]`
- MBPP 262 (typed): Changed `Any` to `Tuple[List[Any], List[Any]]` to match the docstring and tests
- MBPP 407 (typed): Changed `Any` to `Union[int, bool]`.
    - Could be `Union[int, Literal[False]]` to be more accurate, but existing translators won't handle this
- MBPP 413 (typed): Changed `List[Any]` to `List[Union[str, int]]`, as the input was restricted to only contain strings and integers.
    - Note that based on the docstring, you could also change the input typehint to take `List[Tuple[Any, ...]]`, and leave the return type as `List[Any]`
- MBPP 446 (typed): Changed `Any` to `Tuple[Any, ...]`
- MBPP 587 (typed): Changed `Any` to `Tuple[int, ...]`
- MBPP 595 (typed): Changed `Any` to `Union[int, Literal['Not Possible']`
    - Note that translators almost certainly don't currently support this typehint. That said, without the typehint, this problem should have been impossible without cheating. How are you supposed to know to return that string :facepalm:
- MBPP 725 (typed): Changed `List[Any]` to `List[str]`
- MBPP 726 (typed): Changed `List[Any]` to `List[int]`
- MBPP 744 (typed): Changed `Any` to `Tuple[Any, ...]`
- MBPP 754 (typed): Changed `List[Any]` to `List[int]`

</details>

<details>

<summary>There are also a number of other things that I noticed but didn't change, mostly because I wasn't confident about the solution, but that maybe should still be looked into. Let me know if you'd like me to raise an issue to capture these.</summary>

- MBPP 115 - Docstring states it takes a list of dictionaries. Test cases contain both list of dictionaries and dictionary not in a list.
- MBPP 117 - Docstring states it takes a list of list. Test cases contain list of tuples
- MBPP 401 - Docstring and test cases are list of lists. Function and parameter names indicate they should be tuples of tuples.
- MBPP 417 - Function name implies tuples, everything else implies or uses lists
- MBPP 431 - Bizarre tests that expect the return value to be True or None, not True or False. Typehint could be updated to `Optional[Literal[True]]`, though the existing translators wouldn't support this.
- MBPP 444 - Function name implies tuples, everything else implies or uses lists
- MBPP 582 - Function name, argument name, and docstring state that the function should check if a dictionary is empty. But two out of 3 test cases use a set, not a dictionary, and the version with typehints specifies that it takes a Set not a Dict.
- MBPP 756 - Duplicate of 434. Should it be removed?

</details>