### PR TITLE
Escape double quotes in Clojure docstrings

### DIFF
--- a/dataset_builder/humaneval_to_clj.py
+++ b/dataset_builder/humaneval_to_clj.py
@@ -14,7 +14,8 @@ class Translator:
 
     def translate_prompt(self, name: str, args: List[ast.arg], _returns, description: str) -> str:
         # print(description)
-        clojure_description = f'"{description}"' if description else ""
+        escaped_description = description.replace('"', '\\"')
+        clojure_description = f'"{escaped_description}"' if description else ""
         arg_names = [arg.arg for arg in args]
         arg_list = " ".join(arg_names)
         self.entry_point = name


### PR DESCRIPTION
Fix corrupted prompts (61 out of 161).